### PR TITLE
Added Die Chart to README.txt

### DIFF
--- a/Queller-console/README.txt
+++ b/Queller-console/README.txt
@@ -21,9 +21,9 @@ my email: ppslima@gmail.com with the subject "Queller".
  ************************
  *      DIE CHARTS      *
  *  C: Character        *
- *  A: Army	           *
+ *  A: Army	          *
  *  M: Muster	         *
- *  E: Eye 	           *
+ *  E: Eye 	          *
  *  B: Battle	         *
  *  P: Palantir (Event) *
  ************************

--- a/Queller-console/README.txt
+++ b/Queller-console/README.txt
@@ -21,9 +21,9 @@ my email: ppslima@gmail.com with the subject "Queller".
  ************************
  *      DIE CHARTS      *
  *  C: Character        *
- *  A: Army	          *
+ *  A: Army	           *
  *  M: Muster	         *
- *  E: Eye 	          *
+ *  E: Eye 	           *
  *  B: Battle	         *
  *  P: Palantir (Event) *
  ************************

--- a/Queller-console/README.txt
+++ b/Queller-console/README.txt
@@ -16,6 +16,17 @@ Observations:
 4. An action is indicated by arrowheads ">>> ACTION <<<"
 5. Give me feedback on the topic on BGG, BGG mail (Fubanga) or
 my email: ppslima@gmail.com with the subject "Queller".
+6. Dice characters used by Queller:
+
+ ************************
+ *      DIE CHARTS      *
+ *  C: Character        *
+ *  A: Army	            *
+ *  M: Muster	          *
+ *  E: Eye 	            *
+ *  B: Battle	          *
+ *  P: Palantir (Event) *
+ ************************
 
 Have fun!
 ---------
@@ -28,8 +39,8 @@ v1.4:
 v1.3:
 - Fixed missing text for a certain action
 - Fixed typos
-- Changed Nazgûl placement priority for the special case of "Nazgûl Search" card.
-- Changed text of Character Chart from "Die has been used?" to "Were you able to move any Minion or Nazgûl?"?
+- Changed NazgÃ»l placement priority for the special case of "NazgÃ»l Search" card.
+- Changed text of Character Chart from "Die has been used?" to "Were you able to move any Minion or NazgÃ»l?"?
 
 v1.2:
 - Added changelog to record the changes history

--- a/Queller-console/README.txt
+++ b/Queller-console/README.txt
@@ -21,10 +21,10 @@ my email: ppslima@gmail.com with the subject "Queller".
  ************************
  *      DIE CHARTS      *
  *  C: Character        *
- *  A: Army	            *
- *  M: Muster	          *
- *  E: Eye 	            *
- *  B: Battle	          *
+ *  A: Army	           *
+ *  M: Muster	        *
+ *  E: Eye 	           *
+ *  B: Battle	        *
  *  P: Palantir (Event) *
  ************************
 

--- a/Queller-console/README.txt
+++ b/Queller-console/README.txt
@@ -21,10 +21,10 @@ my email: ppslima@gmail.com with the subject "Queller".
  ************************
  *      DIE CHARTS      *
  *  C: Character        *
- *  A: Army	           *
- *  M: Muster	        *
- *  E: Eye 	           *
- *  B: Battle	        *
+ *  A: Army	          *
+ *  M: Muster	         *
+ *  E: Eye 	          *
+ *  B: Battle	         *
  *  P: Palantir (Event) *
  ************************
 

--- a/Queller-console/README.txt
+++ b/Queller-console/README.txt
@@ -21,9 +21,9 @@ my email: ppslima@gmail.com with the subject "Queller".
  ************************
  *      DIE CHARTS      *
  *  C: Character        *
- *  A: Army	          *
+ *  A: Army	         *
  *  M: Muster	         *
- *  E: Eye 	          *
+ *  E: Eye 	         *
  *  B: Battle	         *
  *  P: Palantir (Event) *
  ************************


### PR DESCRIPTION
I was testing out the Queller java program and realized I didn't know the code for the "Will of the West/Eye" dice result. I looked in the README but didn't find anything. I dug through the code and found the die chart, but the F character (for Faction) didn't work either. I had to comb through the ConstantUtil.java file to find that P was the character for the Event die face, and E was the character for the Eye die face.

I added the die chart to the README as a reference for those unfamiliar with the Queller java program syntax. 

Thank you for your work on the Java console, it's really fun and easy to play against when other opponents are unavailable!